### PR TITLE
[CST-478] Fix the device capability lost issue when reset the kubelet

### DIFF
--- a/server.go
+++ b/server.go
@@ -85,6 +85,10 @@ func (m *HabanalabsDevicePlugin) Start() error {
 		return err
 	}
 
+        if m.stop == nil {
+                m.stop = make(chan interface{})
+        }
+
 	//  initialize Devices
 	m.devs = m.Devices()
 
@@ -120,6 +124,7 @@ func (m *HabanalabsDevicePlugin) Stop() error {
 	m.server.Stop()
 	m.server = nil
 	close(m.stop)
+	m.stop = nil
 
 	return m.cleanup()
 }


### PR DESCRIPTION
Fix the device capability lost issue when reset the kubelet service.

Change-Id: I4b008ed376e529ec6258b6ccc91f4a9a344621a7