### PR TITLE
Supported cards driver drop/recovery detection mechanism.

### DIFF
--- a/habanalabs.go
+++ b/habanalabs.go
@@ -115,7 +115,7 @@ func getDevice(devs []*pluginapi.Device, id string) *pluginapi.Device {
 	return nil
 }
 
-func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *pluginapi.Device) {
+func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *pluginapi.Device, healthyDevices chan<- *pluginapi.Device, unhealthyDevices map[string]*pluginapi.Device) {
 	eventSet := hlml.NewEventSet()
 	defer hlml.DeleteEventSet(eventSet)
 
@@ -124,6 +124,7 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 		if err != nil {
 			slog.Error("Failed registering critial event for device. Marking it unhealthy", "device_id", d.ID, "error", err)
 			xids <- d
+			unhealthyDevices[d.ID] = d
 			continue
 		}
 	}
@@ -138,11 +139,33 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 		case <-healthCheckInterval.C:
 			e, err := hlml.WaitForEvent(eventSet, 1000)
 			if err != nil {
-				slog.Error("hlml WaitForEvent failed", "errror", err.Error())
+				for id, d := range unhealthyDevices {
+					err := hlml.RegisterEventForDevice(eventSet, hlml.HlmlCriticalError, id)
+					if err == nil {
+						slog.Info("Device has recovered and is now healthy", "device_id", id)
+						healthyDevices <- d
+						delete(unhealthyDevices, id)
+					}
+				}
+				for _, d := range devs {
+					err := hlml.RegisterEventForDevice(eventSet, hlml.HlmlCriticalError, d.ID)
+					if err != nil {
+						slog.Error("hlml wait for event failed for device, marking it unhealthy", "device_id", d.ID, "error", err)
+						unhealthyDevices[d.ID] = d
+						xids <- d
+					}
+				}
 				time.Sleep(2 * time.Second)
 				continue
 			}
-
+			for id, d := range unhealthyDevices {
+				err := hlml.RegisterEventForDevice(eventSet, hlml.HlmlCriticalError, id)
+				if err == nil {
+					slog.Info("Device has recovered and is now healthy", "device_id", id)
+					healthyDevices <- d
+					delete(unhealthyDevices, id)
+				}
+			}
 			if e.Etype != hlml.HlmlCriticalError {
 				continue
 			}


### PR DESCRIPTION
issue background: comes from tencent customers. when a driver or physical card drop occurs in a cluster environment, it is hoped that the device plugin can perceive these changes.

**A. Instructions**,

1. When a card drop occurs, hlml.WaitForEvent will generate an unknown error status. so when an unknown error occurs, use the event function of the registered card to judge the driver status of all cards. If the registration fails, it means that the current card is in the driver drop state, otherwise the card driver is normal.

2. If it is in the driver drop state, the card will be marked as unhealthy and the nodes in the cluster environment will be notified to update the status of the allocable cards.

3. Add a driver drop status structure unhealthyDevices, which will be recorded every time the driver drops.

4. During each card health status detection, all recorded unhealthy devices will be checked to see if the driver has recovered.

**B. Verification**,

1. Deploy the K8s environment and deploy the Habana device plugin when the Gaudi card is in normal state.
2. Check the number of Gaudi cards that can be allocated on the node node in the cluster environment.  (8)  
    ![image](https://github.com/user-attachments/assets/1485bd04-61fd-4b60-bc6d-f426a8e75c13)


3. Simulate the driver card drop method:
    Command: 
    >          echo '0000:5a:00.0' | sudo tee /sys/bus/pci/drivers/habanalabs/unbind
    >          echo '0000:48:00.0' | sudo tee /sys/bus/pci/drivers/habanalabs/unbind
      hl-smi output:
        ![image](https://github.com/user-attachments/assets/b02a5f7d-0749-401f-bc86-4c18363c536f)


4. Check the output of the Habana device plugin log and the allocatable number of Gaudi cards on the node again. 
a.    Device plugin log: will print the card drop status:
![image](https://github.com/user-attachments/assets/90454ce2-877d-4873-923b-ab30453ec4ad)
b.	Check the number of cards that can be allocated on the node : (8 -> 6)
![image](https://github.com/user-attachments/assets/8bfadbac-fd7c-4b5a-863b-fa1314ce23c8)


5. Cards driver recovery:
    Command:
    >          echo '0000:5a:00.0' | sudo tee /sys/bus/pci/drivers/habanalabs/bind
    >          echo '0000:48:00.0' | sudo tee /sys/bus/pci/drivers/habanalabs/bind   
     hl-smi output:
         ![image](https://github.com/user-attachments/assets/09a36ec9-647f-497b-b807-5ab0df0407aa)
          
6. Verify the Habana device plugin log and the allocatable number of Guadi cards on the node. 
a.	Device plugin log: will print the card recovery  status:
![image](https://github.com/user-attachments/assets/c3084993-b7be-46af-9e42-c7289d5c0360)
![image](https://github.com/user-attachments/assets/ca5d8954-77e8-4d1c-8003-602a246a1234)
b.	Check the number of cards that can be allocated on the node: (6->8)
![image](https://github.com/user-attachments/assets/33bfa5f2-3d02-45f0-bf42-fc4d8025cb36)


